### PR TITLE
Adds the actual filename to proxy downloading

### DIFF
--- a/routes/resources.js
+++ b/routes/resources.js
@@ -305,7 +305,8 @@ module.exports = function (express, config) {
             }
         }, resp => {
             console.log(resp.statusCode + " " + url);
-            res.set('Content-disposition', 'attachment; filename=' + encodeURI(version.uuid));
+            const filename = resp.headers['content-disposition'].split("=")[1].replace(";", "");
+            res.set('Content-disposition', 'attachment; filename=' + encodeURI(filename));
             res.set('Content-Type', 'application/octet-stream');
             res.set('Cache-Control', 'public, max-age=604800, immutable')
             resp.pipe(res);

--- a/routes/resources.js
+++ b/routes/resources.js
@@ -305,7 +305,7 @@ module.exports = function (express, config) {
             }
         }, resp => {
             console.log(resp.statusCode + " " + url);
-            const filename = resp.headers['content-disposition'].split("=")[1].replace(";", "");
+            const filename = resp.headers['content-disposition'].split("=")[1].replace(";", "").replaceAll('"', "");
             res.set('Content-disposition', 'attachment; filename=' + encodeURI(filename));
             res.set('Content-Type', 'application/octet-stream');
             res.set('Cache-Control', 'public, max-age=604800, immutable')

--- a/routes/resources.js
+++ b/routes/resources.js
@@ -305,8 +305,7 @@ module.exports = function (express, config) {
             }
         }, resp => {
             console.log(resp.statusCode + " " + url);
-            const filename = resp.headers['content-disposition'].split("=")[1].replace(";", "").replaceAll('"', "");
-            res.set('Content-disposition', 'attachment; filename=' + encodeURI(filename));
+            res.set('Content-disposition', resp.headers['content-disposition']);
             res.set('Content-Type', 'application/octet-stream');
             res.set('Cache-Control', 'public, max-age=604800, immutable')
             resp.pipe(res);


### PR DESCRIPTION
Using the response headers from Spigot, we can use the content-disposition header and just return that with the response headers from the API.

Ignore the first 2 commits, I was trying to get the filename from the header itself but realised it's probably easier to just return the header directly from Spigot. 